### PR TITLE
Remove unused search parameters and related types and fix part color types

### DIFF
--- a/packages/types/data/part-color.ts
+++ b/packages/types/data/part-color.ts
@@ -1,13 +1,24 @@
-// PartColor type for /api/v3/lego/parts/${string}/colors/
+/**
+ * Part Category (/api/v3/lego/parts/{part_num}/colors/).
+ *
+ * @see https://rebrickable.com/api/v3/docs
+ */
 export interface PartColor {
-  /** Color ID */
-  id: number;
-  /** Color name */
-  name: string;
-  /** RGB hex string */
-  rgb: string;
-  /** Is transparent */
-  is_trans: boolean;
-  /** List of element IDs for this part/color */
-  elements: string[];
+  /** The part color ID */
+	color_id: number;
+
+  /** The part color name */
+	color_name: string;
+
+  /** Number of sets that use this part/color combination */
+	num_sets: number;
+
+  /** Number of parts in sets that use this part/color combination */
+	num_set_parts: number;
+
+  /** The part image URL */
+	part_img_url: string;
+
+  /** Elements IDs for this part/color combination */
+	elements: string[];
 }

--- a/packages/types/data/part-color.ts
+++ b/packages/types/data/part-color.ts
@@ -1,0 +1,13 @@
+// PartColor type for /api/v3/lego/parts/${string}/colors/
+export interface PartColor {
+  /** Color ID */
+  id: number;
+  /** Color name */
+  name: string;
+  /** RGB hex string */
+  rgb: string;
+  /** Is transparent */
+  is_trans: boolean;
+  /** List of element IDs for this part/color */
+  elements: string[];
+}

--- a/packages/types/endpoints.ts
+++ b/packages/types/endpoints.ts
@@ -6,6 +6,7 @@ import type { Part } from './data/part';
 import type { PartCategory } from './data/part-categories';
 import type { Set } from './data/set';
 import type { Theme } from './data/theme';
+import type { PartColor } from './data/part-color';
 
 type BasePath = '/api/v3';
 
@@ -99,7 +100,7 @@ export type EndpointType<Url extends KnownEndpoint | (string & {})> =
   Url extends BulkExpandedEndpointUrl<'/api/v3/lego/part_categories/', number> ? BulkExpandedResponseType<'/api/v3/lego/part_categories/', Url, number, PartCategory> :
   Url extends BulkExpandedEndpointUrl<'/api/v3/lego/sets/', string> ? BulkExpandedResponseType<'/api/v3/lego/sets/', Url, string, Set> :
   Url extends BulkExpandedEndpointUrl<'/api/v3/lego/themes/', number> ? BulkExpandedResponseType<'/api/v3/lego/themes/', Url, number, Theme> :
-  Url extends `/api/v3/lego/parts/${string}/colors/` ? PaginatedResponseType<Url, Color> :
+  Url extends `/api/v3/lego/parts/${string}/colors/` ? PaginatedResponseType<Url, PartColor> :
   Url extends PaginatedEndpointUrl<`/api/v3/lego/sets/${string}/parts/`> ? PaginatedResponseType<`/api/v3/lego/sets/${string}/parts/`, InventoryPart> :
   Url extends BulkExpandedEndpointUrl<'/api/v3/lego/parts/', string> ? BulkExpandedResponseType<'/api/v3/lego/parts/', Url, string, Part> :
   // fallback for all bulk expanded URLs

--- a/packages/types/endpoints.ts
+++ b/packages/types/endpoints.ts
@@ -54,10 +54,6 @@ type WithParameters<Url extends string, Parameters extends string | undefined = 
 type PaginatedParameters = `page=${number}` | `page_size=${number}` | CombineParameters<`page=${number}`, `page_size=${number}`>;
 type PaginatedEndpointUrl<Endpoint extends KnownEndpoint> = Endpoint | WithParameters<Endpoint, PaginatedParameters>;
 
-// helper for search parameters
-type SearchParameters = `search=${string}`;
-type SearchEndpointUrl<Endpoint extends KnownEndpoint> = Endpoint | WithParameters<Endpoint, SearchParameters>;
-
 type PaginatedResponseType<Endpoint extends KnownEndpoint, T> =
   Endpoint extends PaginatedEndpointUrl<KnownEndpoint> ? { count: number, next: string | null, previous: string | null, results: T[] } :
   unknown;


### PR DESCRIPTION
Quick fix to resolve typescript compilation errors when library types are used implemented. solves #22 